### PR TITLE
[FEATURE] Add `twspace-crawler` as a global command-line executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,89 @@
 # twspace-crawler
 
-## Description
+> **Node.js script & command-line app to automatically monitor & download [Twitter Spaces](https://help.twitter.com/en/using-twitter/spaces).**
 
-Script to monitor & download Twitter Spaces.
+
 
 ## Note
 
 - Please set `TWITTER_AUTHORIZATION` or `TWITTER_AUTH_TOKEN` for better Spaces lookup
 - Without above config, script will try to fetch user tweets for live Spaces, which could result empty if user not tweet that Space
 
-## Requirements
+
+
+## Contents
+
+1. [Requirements](#requirements)
+1. [Installation](#installation)
+1. [Usage](#usage)
+1. [Options](#options)
+1. [Commands](#commands)
+1. [Advanced Usage](#advanced-usage)
+
+
+
+## <a name="requirements"/></a> Requirements
 
 - [Node 14](https://nodejs.org/) ([Ubuntu](https://linuxize.com/post/how-to-install-node-js-on-ubuntu-20-04/))
 - [ffmpeg](https://www.ffmpeg.org/) ([Ubuntu](https://linuxize.com/post/how-to-install-ffmpeg-on-ubuntu-20-04/))
 
-## Installation
 
-```
-npm install
-```
 
-```
-npm run build
-```
+## <a name="installation"/></a> Installation
 
-## Usage
+### Command-line installation
 
-Monitor user(s) indefinitely, wait for live Space and download when Space ended
-
-```
-node ./dist/index.js --user nakiriayame
+```bash
+npm install --global twspace-crawler
 ```
 
+### Module installation
+
+```bash
+npm install twspace-crawler
 ```
-node ./dist/index.js --user nakiriayame,sakamatachloe
+
+
+
+## <a name="usage"/></a> Usage
+
+
+### Monitor user(s) indefinitely, wait for live Space and download when Space ended
+
+```
+twspace-crawler --user nakiriayame
 ```
 
 ```
-node ./dist/index.js --config ./config.json
+twspace-crawler --user nakiriayame,sakamatachloe
 ```
 
-Monitor & download Space by id
+```
+twspace-crawler --config ./config.json
 
 ```
-node ./dist/index.js --id 1yoJMWvbybNKQ
-```
 
-Download Space by playlist url
+### Monitor & download Space by id
 
 ```
-node ./dist/index.js --url https://prod-fastly-ap-northeast-1.video.pscp.tv/Transcoding/v1/hls/1Nq1QFkYTQ4v1X4BTV_aJ_pFeQhYyuYXY7ykz5xB7v5NvGwFMJMKwnRBmxyi9twF4BZ90ZKks5wdGKqESVsjLw...
+twspace-crawler --id 1yoJMWvbybNKQ
 ```
 
-Download Space by playlist url with additional metadata (if Space url still available)
+### Download Space by playlist url
 
 ```
-node ./dist/index.js --id 1yoJMWvbybNKQ --url https://prod-fastly-ap-northeast-1.video.pscp.tv/Transcoding/v1/hls/1Nq1QFkYTQ4v1X4BTV_aJ_pFeQhYyuYXY7ykz5xB7v5NvGwFMJMKwnRBmxyi9twF4BZ90ZKks5wdGKqESVsjLw...
+twspace-crawler --url https://prod-fastly-ap-northeast-1.video.pscp.tv/Transcoding/v1/hls/1Nq1QFkYTQ4v1X4BTV_aJ_pFeQhYyuYXY7ykz5xB7v5NvGwFMJMKwnRBmxyi9twF4BZ90ZKks5wdGKqESVsjLw...
 ```
 
-## Options
+### Download Space by playlist url with additional metadata (if Space url still available)
+
+```
+twspace-crawler --id 1yoJMWvbybNKQ --url https://prod-fastly-ap-northeast-1.video.pscp.tv/Transcoding/v1/hls/1Nq1QFkYTQ4v1X4BTV_aJ_pFeQhYyuYXY7ykz5xB7v5NvGwFMJMKwnRBmxyi9twF4BZ90ZKks5wdGKqESVsjLw...
+```
+
+
+
+## <a name="options"/></a> Options
 
 ```
   -h, --help                Display help
@@ -75,7 +100,9 @@ node ./dist/index.js --id 1yoJMWvbybNKQ --url https://prod-fastly-ap-northeast-1
   --force-open              Force open Space in browser
 ```
 
-## Commands
+
+
+## <a name="commands"/></a> Commands
 
 Use to manually process audio/captions
 
@@ -94,14 +121,16 @@ Use to manually process audio/captions
 ### Example
 
 ```
-node ./dist/index.js cc d 1yoJMWneoZwKQ https://prod-chatman-ancillary-ap-northeast-1.pscp.tv 2Ozpcu2xxqb5wxMdkyodUCygOrbYMLv8rq...
+twspace-crawler cc d 1yoJMWneoZwKQ https://prod-chatman-ancillary-ap-northeast-1.pscp.tv 2Ozpcu2xxqb5wxMdkyodUCygOrbYMLv8rq...
 ```
 
 ```
-node ./dist/index.js cc e /download/sample_cc.jsonl
+twspace-crawler cc e /download/sample_cc.jsonl
 ```
 
-## Advanced Usage
+
+
+## <a name="advanced-usage"/></a> Advanced Usage
 
 - To monitor multiple users, it is better to use [Twitter API v2](https://developer.twitter.com/en/docs/twitter-api/spaces/overview)
     1. [Getting access to the Twitter API](https://developer.twitter.com/en/docs/twitter-api/getting-started/getting-access-to-the-twitter-api)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "test": "lab --transform node_modules/lab-transform-typescript",
     "lint": "eslint src --ext .ts",
-    "lint-fix": "eslint src --ext .ts --fix"
+    "lint-fix": "eslint src --ext .ts --fix",
+    "prepare": "npm run build"
   },
   "author": "HitomaruKonpaku",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
     "lab-transform-typescript": "^3.0.1",
     "typescript": "^4.4.4"
   },
+  "engines": {
+    "node": ">=14.0.0",
+    "npm": ">= 6.0.0"
+  },
   "bin": {
     "twspace-crawler": "dist/index.js"
   }

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "lab-transform-typescript": "^3.0.1",
     "typescript": "^4.4.4"
+  },
+  "bin": {
+    "twspace-crawler": "dist/index.js"
   }
 }

--- a/src/constants/app.constant.ts
+++ b/src/constants/app.constant.ts
@@ -1,5 +1,5 @@
-export const APP_CACHE_DIR = '../../.cache'
-export const APP_MEDIA_DIR = '../../.media'
+export const APP_CACHE_DIR = './.cache'
+export const APP_MEDIA_DIR = './.media'
 export const APP_USER_REFRESH_INTERVAL = 30000
 export const APP_SPACE_ERROR_RETRY_INTERVAL = 5000
 export const APP_PLAYLIST_REFRESH_INTERVAL = 10000

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { program } from 'commander'
 import 'dotenv/config'
 import { ccCommand } from './commands/cc.command'

--- a/src/modules/SpaceDownloader.ts
+++ b/src/modules/SpaceDownloader.ts
@@ -78,7 +78,7 @@ export class SpaceDownloader {
     this.logger.verbose(`Audio is saving to "${this.audioFile}"`)
     this.logger.verbose(`${cmd} ${args.join(' ')}`)
 
-    const spawnOptions: SpawnOptions = { detached: true, stdio: 'ignore' }
+    const spawnOptions: SpawnOptions = { detached: true, stdio: 'ignore', cwd: process.cwd() }
     const cp = process.platform === 'win32'
       ? spawn(process.env.comspec, ['/c', cmd, ...args], spawnOptions)
       : spawn(cmd, args, spawnOptions)

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -28,7 +28,7 @@ export class Util {
   }
 
   public static getCacheDir(subDir = ''): string {
-    return path.join(__dirname, APP_CACHE_DIR, subDir || '')
+    return path.join(process.cwd(), APP_CACHE_DIR, subDir || '')
   }
 
   public static createCacheDir(subDir = ''): string {
@@ -36,7 +36,7 @@ export class Util {
   }
 
   public static getMediaDir(subDir = ''): string {
-    return path.join(__dirname, APP_MEDIA_DIR, subDir || '')
+    return path.join(process.cwd(), APP_MEDIA_DIR, subDir || '')
   }
 
   public static createMediaDir(subDir = ''): string {


### PR DESCRIPTION
## 📋 Description
This pull request adds a global `twspace-crawler` binary executable through `package.json` via the standard facilities [provided by npm](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#bin). This enables users to run the script through a globally available `twspace-crawler` executable instead of directly referencing `dist/index.js`, like so:

```bash
user@home:~$ twspace-crawler --debug
```

The documentation README has also been updated and extended to reflect the changes.

## 🗂 Type
- [x] 🍾 Feature

## 🔥 Severity
- [x] 💎 Non-Breaking Changes

## 🛃 Tests
<!---
Check one box.
-->
- [x] My changes have been tested manually.
