### PR TITLE
[FEATURE] Add `--space-url` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ twspace-crawler --id 1yoJMWvbybNKQ --url https://prod-fastly-ap-northeast-1.vide
   --config <CONFIG_PATH>    Path to config file (See config.example.json)
   --user <USER>             Monitor & download live Spaces from users indefinitely,
                             separate by comma (,)
-  --id <SPACE_ID>           Monitor & download live Space with id
+  --id <SPACE_ID>           Watch & download live Space with its id
+  --space-url <SPACE_ID>    Watch & download live Space with its URL
   --force                   Force download Space when using with --id
   --url <PLAYLIST_URL>      Download Space using playlist url
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { SpaceDownloader } from './modules/SpaceDownloader'
 import { userManager } from './modules/UserManager'
 import { CommandUtil } from './utils/CommandUtil'
 import { Util } from './utils/Util'
+import { TwitterUtil } from './utils/TwitterUtil'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkg = require('../package.json')
@@ -39,7 +40,8 @@ program
   .option('--env <ENV_PATH>', 'Path to .env file, default to current working folder (See .env.example)')
   .option('--config <CONFIG_PATH>', 'Path to config file (See config.example.json)')
   .option('--user <USER>', 'Watch & download live Spaces from users, separate by comma (,)')
-  .option('--id <SPACE_ID>', 'Watch & download live Space with id')
+  .option('--id <SPACE_ID>', 'Watch & download live Space with its id')
+  .option('--space-url <SPACE_URL>', 'Watch & download live Space with its URL')
   .option('--force', 'Force download Space when using with --id')
   .option('--url <PLAYLIST_ID>', 'Download Space using playlist url')
   .option('--notification', 'Show notification about new live Space')
@@ -70,16 +72,31 @@ program.action(async (args, cmd: Command) => {
 
   configManager.load()
 
-  const { url, id, user } = args
-  if (url && !id) {
-    logger.info('Starting in url mode', { url })
+  const {
+    url, id, spaceUrl, user,
+  } = args
+  if (url && !id && !spaceUrl) {
+    logger.info('Starting in playlist url mode', { url })
     new SpaceDownloader(url, Util.getDateTimeString()).download()
     return
   }
 
-  if (id) {
+  if (id && !spaceUrl) {
     logger.info('Starting in space id mode', { id })
     mainManager.addSpaceWatcher(id)
+    return
+  }
+
+  if (spaceUrl) {
+    logger.info('Starting in space url mode', { spaceUrl })
+
+    const spaceId = TwitterUtil.getSpaceId(spaceUrl)
+    if (!spaceId) {
+      logger.error(`Space URL invalid: ${spaceUrl}`)
+      return
+    }
+
+    mainManager.addSpaceWatcher(spaceId)
     return
   }
 

--- a/src/utils/TwitterUtil.ts
+++ b/src/utils/TwitterUtil.ts
@@ -1,9 +1,29 @@
 export class TwitterUtil {
+  /**
+   * Returns the URL of a Twitter user, provided their user name
+   * @param {string} username - User name
+   * @returns {string} User URL
+   */
   public static getUserUrl(username: string) {
     return `https://twitter.com/${username}`
   }
 
+  /**
+   * Returns the URL of a Twitter Space, provided its identifier
+   * @param {string} spaceId - Space identifier
+   * @returns {string} Space URL
+   */
   public static getSpaceUrl(spaceId: string) {
     return `https://twitter.com/i/spaces/${spaceId}`
+  }
+
+  /**
+   * Returns the identifier of a Twitter Space, provided its URL
+   * @param {string} spaceUrl - Space URL
+   * @returns {?string} Space identifier
+   */
+  public static getSpaceId(spaceUrl: string): string | null {
+    const matches = /(?:spaces\/)?([A-Za-z0-9_]{13})/i.exec(spaceUrl) || []
+    return matches[1]
   }
 }


### PR DESCRIPTION
## 📋 Description
This pull request add the `--space-url` argument to twspace-crawler. This enables users to reference a Twitter Space using its URL, which is obtained via the `Share` feature available in many Twitter clients.

**Example:**
```bash
user@home:~$ twspace-crawler --space-url "https://twitter.com/i/spaces/1yoJMWvbybNKQ"
```

Additional utility methods have been integrated in line with existing feature implementations.
The README has been updated to reflect the changes.

## 🗂 Type
- [x] 🍾 Feature

## 🔥 Severity
- [x] 💎 Non-Breaking Changes

## 🛃 Tests
- [x] My changes have been tested manually.
